### PR TITLE
Remove the resource_prefix variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,9 +25,3 @@ variable "top_level_domain_name" {
   type        = "string"
   default     = "build.gds-reliability.engineering"
 }
-
-variable "resource_prefix" {
-  description = "Prefix for resources created in this module"
-  type        = "string"
-  default     = ""
-}


### PR DESCRIPTION
Remove the resource_prefix variable as it does not seem to be referenced anywhere else.

I `git grep`'ed both our modules and the main repo, but this does not seem to be referenced.

Also, I don't think this is a default variable name that Terraform will automagically use.

As we don't use it, we should remove it.